### PR TITLE
Install iproute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN yum -y install rpm dnf-plugins-core \
       python3 \
       python3-pip \
       python3-pyyaml \
+      iproute \
  && yum clean all
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip \


### PR DESCRIPTION
Sorry if this done incorrectly.  Fairly new to the process.  Per [Package requirements for fact gathering](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering),  the iproute package is needed to gather network facts.  It seems the almalinux 8 docker image doesn't ship it by default.